### PR TITLE
Makes sure no return keys make it into the ruby version

### DIFF
--- a/lib/mina/config.rb
+++ b/lib/mina/config.rb
@@ -34,7 +34,7 @@ unless environments.nil?
 
       set :ruby_version, File.read('.ruby-version')
 
-      invoke :"rvm:use[#{ruby_version}]"
+      invoke :"rvm:use[#{ruby_version.chomp}]"
     end
   end
 

--- a/lib/mina/config/kohana.rb
+++ b/lib/mina/config/kohana.rb
@@ -1,0 +1,12 @@
+
+
+# Kohana deployment tasks
+set :platform, :kohana
+namespace :mina_config do
+  namespace :platform do
+    namespace :kohana do
+      task :tasks do
+      end
+    end
+  end
+end

--- a/lib/mina/config/php.rb
+++ b/lib/mina/config/php.rb
@@ -1,0 +1,12 @@
+
+
+# Kohana deployment tasks
+set :platform, :php
+namespace :mina_config do
+  namespace :platform do
+    namespace :php do
+      task :tasks do
+      end
+    end
+  end
+end

--- a/lib/mina/config/rails.rb
+++ b/lib/mina/config/rails.rb
@@ -1,0 +1,16 @@
+
+
+# Rails deployment tasks
+set :platform, :rails
+namespace :mina_config do
+  namespace :platform do
+    namespace :rails do
+      task :tasks do
+        set :ruby_version, File.read('.ruby-version')
+
+        desc "Setting rvm to use ruby version #{ruby_version}"
+        invoke :"rvm:use[#{ruby_version.chomp}]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
If there's any return key added in the .ruby-version file, the deployment will fail. This fixes that. 
