### PR TITLE
Don't require a .ruby-version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adds a multi-environment yml configuration file to mina. Environment configuration is dynamically created by the definitions in the deploy.yml file.
 
-As of right now the gem does require you to use rvm and have a .ruby-version file.
+As of right now the gem does require you to use rvm and have a .ruby-version file if you are doing a Ruby deployment.
 
 ## Installation
 

--- a/lib/mina/config.rb
+++ b/lib/mina/config.rb
@@ -8,6 +8,7 @@ require 'mina/String'
 
 default_env = fetch(:default_env, 'staging')
 config_file = 'config/deploy.yml'
+ruby_version_file = '.ruby-version'
 set :config, YAML.load(File.open(config_file)).with_indifferent_access if File.exists? config_file
 set :rails_env, ENV['to'] || :staging
 
@@ -34,9 +35,10 @@ unless environments.nil?
 
       set :deploy_to, "/srv/app/#{app}"
 
-      set :ruby_version, File.read('.ruby-version')
-
-      invoke :"rvm:use[#{ruby_version}]"
+      if File.exists?(ruby_version_file)
+        set :ruby_version, File.read(ruby_version_file).strip
+        invoke :"rvm:use[#{ruby_version}]"
+      end
     end
   end
 


### PR DESCRIPTION
Updates to not require a .ruby-version file also strips the contents of the .ruby-config file if it is present. 